### PR TITLE
dev-libs/libclc: Mark a live ebuild properly

### DIFF
--- a/dev-libs/libclc/libclc-9999.ebuild
+++ b/dev-libs/libclc/libclc-9999.ebuild
@@ -21,11 +21,11 @@ if [[ $PV = 9999* ]]; then
 	SRC_URI="${SRC_PATCHES}"
 else
 	SRC_URI="mirror://gentoo/${P}.tar.xz ${SRC_PATCHES}"
+	KEYWORDS="~amd64 ~ppc ~x86"
 fi
 
 LICENSE="|| ( MIT BSD )"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc ~x86"
 IUSE=""
 
 RDEPEND="


### PR DESCRIPTION
Currently Portage simply picks version `9999`. Usually live ebuilds have `KEYWORDS=""` (or no `KEYWORDS` at all) so package manager can ignore them unless user allows their installation by filling an entry in `package.accept_keywords`. This is the desired behavior and the reason for creating this PR.
